### PR TITLE
Allow only master branch to deploy to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,5 +79,8 @@ workflows:
     jobs:
       - build
       - push_to_docker_hub:
+          filters:
+            branches:
+              only: master
           requires:
             - build


### PR DESCRIPTION
For now, other branches are in heavy dev mode, which may be unstable.
So we will deploy to dockerhub only master branch.