### PR TITLE
remove check for updateNode when verify signature in deliverTx and ch…

### DIFF
--- a/abci/did/v1/common.go
+++ b/abci/did/v1/common.go
@@ -683,12 +683,10 @@ func (app *DIDApplication) updateNode(param string, nodeID string) types.Respons
 	// update MasterPublicKey
 	if funcParam.MasterPublicKey != "" {
 		nodeDetail.MasterPublicKey = funcParam.MasterPublicKey
-		app.nodeKeyUpdate[nodeID] = true
 	}
 	// update PublicKey
 	if funcParam.PublicKey != "" {
 		nodeDetail.PublicKey = funcParam.PublicKey
-		app.nodeKeyUpdate[nodeID] = true
 	}
 	// update SupportedRequestMessageDataUrlTypeList and Role of node ID is IdP
 	if funcParam.SupportedRequestMessageDataUrlTypeList != nil && string(app.getRoleFromNodeID(nodeID)) == "IdP" {


### PR DESCRIPTION
Remove check for updateNode when verify signature in deliverTx and use `nodeId|publicKey` instead.
Change verified signature key to `signature|nodeId` to avoid collision.