### PR TITLE
Add a new model 'Message' to the blockchain

### DIFF
--- a/abci/app/v1/checkTx.go
+++ b/abci/app/v1/checkTx.go
@@ -97,6 +97,7 @@ var IsMethod = map[string]bool{
 	"UpdateNamespace":                  true,
 	"SetAllowedMinIalForRegisterIdentityAtFirstIdp": true,
 	"RevokeAndAddAccessor":                          true,
+	"CreateMessage":                                 true,
 }
 
 func (app *ABCIApplication) checkTxInitNDID(param string, nodeID string) types.ResponseCheckTx {
@@ -707,6 +708,8 @@ func (app *ABCIApplication) callCheckTx(name string, param string, nodeID string
 		return app.checkIsRPorIDP(param, nodeID)
 	case "SetMqAddresses":
 		return app.checkTxSetMqAddresses(param, nodeID)
+	case "CreateMessage":
+		return app.checkIsRPorIDP(param, nodeID)
 	default:
 		return types.ResponseCheckTx{Code: code.UnknownMethod, Log: "Unknown method name"}
 	}

--- a/abci/app/v1/common.go
+++ b/abci/app/v1/common.go
@@ -2223,7 +2223,7 @@ func (app *ABCIApplication) getMessage(param string, height int64) types.Respons
 	}
 
 	var res GetMessageResult
-	res.MessageHash = message.MessageHash
+	res.Message = message.Message
 
 	valueJSON, err := json.Marshal(res)
 	if err != nil {
@@ -2262,7 +2262,6 @@ func (app *ABCIApplication) getMessageDetail(param string, height int64, committ
 
 	result.MessageID = message.MessageId
 	result.Message = message.Message
-	result.MessageHash = message.MessageHash
 
 	// Set purpose
 	result.Purpose = message.Purpose

--- a/abci/app/v1/common.go
+++ b/abci/app/v1/common.go
@@ -67,6 +67,7 @@ const (
 	accessorToRefCodeKeyPrefix  = "accessorToRefCodeKey"
 	allowedModeListKeyPrefix    = "AllowedModeList"
 	requestKeyPrefix            = "Request"
+	messageKeyPrefix            = "Message"
 	dataSignatureKeyPrefix      = "SignData"
 	errorCodeKeyPrefix          = "ErrorCode"
 	errorCodeListKeyPrefix      = "ErrorCodeList"
@@ -2196,4 +2197,89 @@ func (app *ABCIApplication) getErrorCodeList(param string) types.ResponseQuery {
 		return app.ReturnQuery(nil, err.Error(), app.state.Height)
 	}
 	return app.ReturnQuery(returnValue, "success", app.state.Height)
+}
+
+func (app *ABCIApplication) getMessage(param string, height int64) types.ResponseQuery {
+	app.logger.Infof("GetMessage, Parameter: %s", param)
+	var funcParam GetMessageParam
+	err := json.Unmarshal([]byte(param), &funcParam)
+	if err != nil {
+		return app.ReturnQuery(nil, err.Error(), app.state.Height)
+	}
+	key := requestKeyPrefix + keySeparator + funcParam.MessageID
+	value, err := app.state.GetVersioned([]byte(key), height, true)
+	if err != nil {
+		return app.ReturnQuery(nil, err.Error(), app.state.Height)
+	}
+
+	if value == nil {
+		valueJSON := []byte("{}")
+		return app.ReturnQuery(valueJSON, "not found", app.state.Height)
+	}
+	var message data.Message
+	err = proto.Unmarshal([]byte(value), &message)
+	if err != nil {
+		return app.ReturnQuery(nil, err.Error(), app.state.Height)
+	}
+
+	var res GetMessageResult
+	res.MessageHash = message.MessageHash
+
+	valueJSON, err := json.Marshal(res)
+	if err != nil {
+		return app.ReturnQuery(nil, err.Error(), app.state.Height)
+	}
+	return app.ReturnQuery(valueJSON, "success", app.state.Height)
+}
+
+func (app *ABCIApplication) getMessageDetail(param string, height int64, committedState bool) types.ResponseQuery {
+	app.logger.Infof("GetMessageDetail, Parameter: %s", param)
+	var funcParam GetMessageParam
+	err := json.Unmarshal([]byte(param), &funcParam)
+	if err != nil {
+		return app.ReturnQuery(nil, err.Error(), app.state.Height)
+	}
+
+	key := messageKeyPrefix + keySeparator + funcParam.MessageID
+	var value []byte
+	value, err = app.state.GetVersioned([]byte(key), height, committedState)
+	if err != nil {
+		return app.ReturnQuery(nil, err.Error(), app.state.Height)
+	}
+
+	if value == nil {
+		valueJSON := []byte("{}")
+		return app.ReturnQuery(valueJSON, "not found", app.state.Height)
+	}
+
+	var result GetMessageDetailResult
+	var message data.Message
+	err = proto.Unmarshal([]byte(value), &message)
+	if err != nil {
+		value = []byte("")
+		return app.ReturnQuery(value, err.Error(), app.state.Height)
+	}
+
+	result.MessageID = message.MessageId
+	result.Message = message.Message
+	result.MessageHash = message.MessageHash
+
+	// Set purpose
+	result.Purpose = message.Purpose
+
+	// Set requester_node_id
+	result.RequesterNodeID = message.Owner
+
+	// Set creation_block_height
+	result.CreationBlockHeight = message.CreationBlockHeight
+
+	// Set creation_chain_id
+	result.CreationChainID = message.ChainId
+
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		value = []byte("")
+		return app.ReturnQuery(value, err.Error(), app.state.Height)
+	}
+	return app.ReturnQuery(resultJSON, "success", app.state.Height)
 }

--- a/abci/app/v1/dataStruct.go
+++ b/abci/app/v1/dataStruct.go
@@ -164,10 +164,9 @@ type CreateIdpResponseParam struct {
 }
 
 type CreateMessageParam struct {
-	MessageID   string `json:"message_id"`
-	Message     string `json:"message"`
-	MessageHash string `json:"message_hash"`
-	Purpose     string `json:"purpose"`
+	MessageID string `json:"message_id"`
+	Message   string `json:"message"`
+	Purpose   string `json:"purpose"`
 }
 
 type GetRequestParam struct {
@@ -205,13 +204,12 @@ type GetMessageParam struct {
 }
 
 type GetMessageResult struct {
-	MessageHash string `json:"message_hash"`
+	Message string `json:"message"`
 }
 
 type GetMessageDetailResult struct {
 	MessageID           string `json:"message_id"`
 	Message             string `json:"message"`
-	MessageHash         string `json:"message_hash"`
 	Purpose             string `json:"purpose"`
 	RequesterNodeID     string `json:"requester_node_id"`
 	CreationBlockHeight int64  `json:"creation_block_height"`

--- a/abci/app/v1/dataStruct.go
+++ b/abci/app/v1/dataStruct.go
@@ -163,6 +163,13 @@ type CreateIdpResponseParam struct {
 	ErrorCode *int32  `json:"error_code"`
 }
 
+type CreateMessageParam struct {
+	MessageID   string `json:"message_id"`
+	Message     string `json:"message"`
+	MessageHash string `json:"message_hash"`
+	Purpose     string `json:"purpose"`
+}
+
 type GetRequestParam struct {
 	RequestID string `json:"request_id"`
 }
@@ -191,6 +198,24 @@ type GetRequestDetailResult struct {
 	RequesterNodeID     string        `json:"requester_node_id"`
 	CreationBlockHeight int64         `json:"creation_block_height"`
 	CreationChainID     string        `json:"creation_chain_id"`
+}
+
+type GetMessageParam struct {
+	MessageID string `json:"message_id"`
+}
+
+type GetMessageResult struct {
+	MessageHash string `json:"message_hash"`
+}
+
+type GetMessageDetailResult struct {
+	MessageID           string `json:"message_id"`
+	Message             string `json:"message"`
+	MessageHash         string `json:"message_hash"`
+	Purpose             string `json:"purpose"`
+	RequesterNodeID     string `json:"requester_node_id"`
+	CreationBlockHeight int64  `json:"creation_block_height"`
+	CreationChainID     string `json:"creation_chain_id"`
 }
 
 type CreateAsResponseParam struct {

--- a/abci/app/v1/deliverTx.go
+++ b/abci/app/v1/deliverTx.go
@@ -223,6 +223,8 @@ func (app *ABCIApplication) callDeliverTx(name string, param string, nodeID stri
 		return app.SetAllowedMinIalForRegisterIdentityAtFirstIdp(param, nodeID)
 	case "RevokeAndAddAccessor":
 		return app.revokeAndAddAccessor(param, nodeID)
+	case "CreateMessage":
+		return app.createMessage(param, nodeID)
 	default:
 		return types.ResponseDeliverTx{Code: code.UnknownMethod, Log: "Unknown method name"}
 	}

--- a/abci/app/v1/query.go
+++ b/abci/app/v1/query.go
@@ -108,6 +108,10 @@ func (app *ABCIApplication) callQuery(name string, param string, height int64) t
 		return app.GetAllowedModeList(param)
 	case "GetAllowedMinIalForRegisterIdentityAtFirstIdp":
 		return app.GetAllowedMinIalForRegisterIdentityAtFirstIdp(param)
+	case "GetMessage":
+		return app.getMessage(param, height)
+	case "GetMessageDetail":
+		return app.getMessageDetail(param, height, true)
 	default:
 		return types.ResponseQuery{Code: code.UnknownMethod, Log: "Unknown method name"}
 	}

--- a/abci/app/v1/rp.go
+++ b/abci/app/v1/rp.go
@@ -461,11 +461,7 @@ func (app *ABCIApplication) createMessage(param string, nodeID string) types.Res
 		return app.ReturnDeliverTxLog(code.DuplicateRequestID, "Duplicate Request ID", "")
 	}
 
-	// set default value
-	request.Purpose = ""
-
 	request.Message = funcParam.Message
-	request.MessageHash = funcParam.MessageHash
 	request.Purpose = funcParam.Purpose
 
 	// set Owner

--- a/abci/app/v1/rp.go
+++ b/abci/app/v1/rp.go
@@ -426,3 +426,62 @@ func (app *ABCIApplication) setDataReceived(param string, nodeID string) types.R
 	}
 	return app.ReturnDeliverTxLog(code.OK, "success", funcParam.RequestID)
 }
+
+func (app *ABCIApplication) createMessage(param string, nodeID string) types.ResponseDeliverTx {
+	app.logger.Infof("CreateMessage, Parameter: %s", param)
+	var funcParam CreateMessageParam
+	err := json.Unmarshal([]byte(param), &funcParam)
+	if err != nil {
+		return app.ReturnDeliverTxLog(code.UnmarshalError, err.Error(), "")
+	}
+	// get RP node detail
+	nodeDetailKey := nodeIDKeyPrefix + keySeparator + nodeID
+	nodeDetaiValue, err := app.state.Get([]byte(nodeDetailKey), false)
+	if err != nil {
+		return app.ReturnDeliverTxLog(code.AppStateError, err.Error(), "")
+	}
+	if nodeDetaiValue == nil {
+		return app.ReturnDeliverTxLog(code.NodeIDNotFound, "Node ID not found", "")
+	}
+	var rpNodeDetail data.NodeDetail
+	err = proto.Unmarshal([]byte(nodeDetaiValue), &rpNodeDetail)
+
+	// log chain ID
+	app.logger.Infof("CreateMessage, Chain ID: %s", app.CurrentChain)
+	var request data.Message
+	// set request data
+	request.MessageId = funcParam.MessageID
+
+	key := messageKeyPrefix + keySeparator + request.MessageId
+	requestIDExist, err := app.state.HasVersioned([]byte(key), false)
+	if err != nil {
+		return app.ReturnDeliverTxLog(code.AppStateError, err.Error(), "")
+	}
+	if requestIDExist {
+		return app.ReturnDeliverTxLog(code.DuplicateRequestID, "Duplicate Request ID", "")
+	}
+
+	// set default value
+	request.Purpose = ""
+
+	request.Message = funcParam.Message
+	request.MessageHash = funcParam.MessageHash
+	request.Purpose = funcParam.Purpose
+
+	// set Owner
+	request.Owner = nodeID
+	// set creation_block_height
+	request.CreationBlockHeight = app.state.CurrentBlockHeight
+	// set chain_id
+	request.ChainId = app.CurrentChain
+
+	value, err := utils.ProtoDeterministicMarshal(&request)
+	if err != nil {
+		return app.ReturnDeliverTxLog(code.MarshalError, err.Error(), "")
+	}
+	err = app.state.SetVersioned([]byte(key), []byte(value))
+	if err != nil {
+		return app.ReturnDeliverTxLog(code.AppStateError, err.Error(), "")
+	}
+	return app.ReturnDeliverTxLog(code.OK, "success", request.MessageId)
+}

--- a/protos/data/data.proto
+++ b/protos/data/data.proto
@@ -95,6 +95,16 @@ message Request {
   string chain_id = 17;
 }
 
+message Message {
+  string message_id = 1;
+  string message = 2;
+  string message_hash = 3;
+  string purpose = 4;
+  string owner = 5;
+  int64 creation_block_height = 6;
+  string chain_id = 7;
+}
+
 message ASResponse {
   string as_id = 1;
   bool signed = 2;

--- a/protos/data/data.proto
+++ b/protos/data/data.proto
@@ -98,11 +98,10 @@ message Request {
 message Message {
   string message_id = 1;
   string message = 2;
-  string message_hash = 3;
-  string purpose = 4;
-  string owner = 5;
-  int64 creation_block_height = 6;
-  string chain_id = 7;
+  string purpose = 3;
+  string owner = 4;
+  int64 creation_block_height = 5;
+  string chain_id = 6;
 }
 
 message ASResponse {


### PR DESCRIPTION
Add a new model, 'Message,' to the blockchain for RP to save the blockchain's custom messages.
For now, the usage is to save E-Stamps and signatures of pdf files.
In the future, the usage is to save any RP messages into the blockchain depend on RP usages.

I am not updating the 'data.pb.go' because I am not sure that 'gen_proto_go.sh' generates the correct file format so after update to this branch the 'gen_proto_go.sh' must be executed before running the service.